### PR TITLE
deps: Set ipfs from env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,13 @@ bin/iptb:
 	@echo "*** building $@ ***"
 	go build -o $@ "$(call gx-path,$(notdir $@))"
 
+IPFS_DEF != which ipfs
+IPFS_CMD ?= $(IPFS_DEF)
+
+bin/ipfs:
+	@echo "*** building $@ ***"
+	cd bin && ln -sf $(IPFS_CMD) ipfs
+
 curl:
 	@which curl >/dev/null || (echo "Please install curl!" && false)
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ For example:
 $ ./t0010-basic-commands.sh -v -i
 ```
 
+## Running against a different ipfs executable
+
+Tests use `bin/ipfs`, by default when bootstrapping dependencies a symlink
+will be created to the first `ipfs` executable found the your `$PATH`. Use the
+`IPFS_CMD` environment variable to set an explicit executable.
+
+```
+$ IPFS_CMD=/path/to/different/ipfs make deps
+```
+
 ## Sharness
 
 When running sharness tests from main Makefile or when `test_sharness_deps`


### PR DESCRIPTION
This allows the setting of the `ipfs` executable through an `IPFS_CMD` environment variable. This also will default to the first `ipfs` executable in the `$PATH` allowing `make deps` to build to `bin/ipfs` dependency.